### PR TITLE
Add speed gauge to Node2D scene

### DIFF
--- a/turborun/node_2d.tscn
+++ b/turborun/node_2d.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://cny343snioslv"]
+[gd_scene load_steps=6 format=3 uid="uid://cny343snioslv"]
 
 [ext_resource type="Texture2D" uid="uid://qgshk0denxw1" path="res://Assets/Car/Black911.png" id="1_0e48y"]
 [ext_resource type="PackedScene" uid="uid://3oeobbhucpd6" path="res://RoadRenderer.tscn" id="1_epypp"]
 [ext_resource type="Script" uid="uid://7upqsae0ej7r" path="res://sprite_2d.gd" id="1_wtcfe"]
 [ext_resource type="AudioStream" uid="uid://ddchtddmo1pk4" path="res://Assets/Music/Tundra17.mp3" id="4_0hol4"]
+[ext_resource type="Script" uid="uid://29c8qy2wsj9b" path="res://speed_gauge.gd" id="1_9x0ay"]
 
 [node name="Node2D" type="Node2D"]
 
@@ -19,3 +20,7 @@ scale_factor = Vector2(0.3, 0.3)
 stream = ExtResource("4_0hol4")
 autoplay = true
 parameters/looping = true
+
+[node name="SpeedLabel" type="Label" parent="."]
+position = Vector2(10, 10)
+script = ExtResource("1_9x0ay")

--- a/turborun/speed_gauge.gd
+++ b/turborun/speed_gauge.gd
@@ -1,0 +1,8 @@
+extends Label
+
+@export var road_renderer_path: NodePath = NodePath("../Node2D")
+@onready var road_renderer = get_node_or_null(road_renderer_path)
+
+func _process(delta: float) -> void:
+    if road_renderer:
+        text = "Speed: %d" % int(road_renderer.current_speed)

--- a/turborun/speed_gauge.gd.uid
+++ b/turborun/speed_gauge.gd.uid
@@ -1,0 +1,1 @@
+uid://29c8qy2wsj9b


### PR DESCRIPTION
## Summary
- Add speed gauge script to show current road speed
- Hook up new speed label in node_2d scene

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68968c9a08688322be9bc2a3df4efcc9