### PR TITLE
Add side walls and collision speed penalty

### DIFF
--- a/turborun/node_2d.tscn
+++ b/turborun/node_2d.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://cny343snioslv"]
+[gd_scene load_steps=10 format=3 uid="uid://cny343snioslv"]
 
 [ext_resource type="Texture2D" uid="uid://qgshk0denxw1" path="res://Assets/Car/Black911.png" id="1_0e48y"]
 [ext_resource type="Script" uid="uid://3ac8qy2wskab" path="res://speed_gauge.gd" id="1_9x0ay"]
@@ -6,6 +6,15 @@
 [ext_resource type="Script" uid="uid://7upqsae0ej7r" path="res://sprite_2d.gd" id="1_wtcfe"]
 [ext_resource type="AudioStream" uid="uid://ddchtddmo1pk4" path="res://Assets/Music/Tundra17.mp3" id="4_0hol4"]
 [ext_resource type="Script" uid="uid://6a17afa7a483" path="res://race_timer.gd" id="5_v5o1p"]
+
+[sub_resource type="RectangleShape2D" id="RectLeft"]
+size = Vector2(20, 300)
+
+[sub_resource type="RectangleShape2D" id="RectRight"]
+size = Vector2(20, 300)
+
+[sub_resource type="RectangleShape2D" id="RectCar"]
+size = Vector2(80, 40)
 
 [node name="Node2D" type="Node2D"]
 
@@ -15,6 +24,23 @@
 texture = ExtResource("1_0e48y")
 script = ExtResource("1_wtcfe")
 scale_factor = Vector2(0.3, 0.3)
+
+[node name="Hitbox" type="Area2D" parent="Sprite2D"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Sprite2D/Hitbox"]
+shape = SubResource("RectCar")
+
+[node name="LeftWall" type="StaticBody2D" parent="."]
+position = Vector2(100, 400)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="LeftWall"]
+shape = SubResource("RectLeft")
+
+[node name="RightWall" type="StaticBody2D" parent="."]
+position = Vector2(700, 400)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="RightWall"]
+shape = SubResource("RectRight")
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_0hol4")

--- a/turborun/sprite_2d.gd
+++ b/turborun/sprite_2d.gd
@@ -9,6 +9,7 @@ extends Sprite2D
 # --- Link to the RoadRenderer node ---------------------------------
 @export var road_gen_path: NodePath = NodePath("../Node2D")
 @onready var road_gen = get_node_or_null(road_gen_path) # resolved on scene load
+@onready var hitbox: Area2D = $Hitbox
 
 # --- Frame indices for the sprite sheet -----------------------------
 const FRAME_LEFT_HARD   = 0
@@ -36,14 +37,15 @@ var left_hold: float  = 0.0      # how long the left key has been held
 var right_hold: float = 0.0      # how long the right key has been held
 
 func _ready() -> void:
-		# Enable regions so we can display one frame from the sprite sheet.
-		region_enabled = true
-		# Determine frame width from the texture if not supplied.
-		if frame_width <= 0 and texture:
-				frame_width = int(texture.get_width() / 5)
-		_apply_frame(FRAME_CENTER)
-		scale = scale_factor
-		_update_position()
+                # Enable regions so we can display one frame from the sprite sheet.
+                region_enabled = true
+                # Determine frame width from the texture if not supplied.
+                if frame_width <= 0 and texture:
+                                frame_width = int(texture.get_width() / 5)
+                _apply_frame(FRAME_CENTER)
+                scale = scale_factor
+                _update_position()
+                hitbox.body_entered.connect(_on_hitbox_body_entered)
 
 func _process(delta: float) -> void:
 		# ------------------------------------------------------------
@@ -80,10 +82,14 @@ func _process(delta: float) -> void:
 		_update_position()
 
 		# Pass steering information to the road renderer so it can bend.
-		if road_gen:
-				road_gen.steering = steer_val
-		else:
-				push_warning("RoadRenderer not found: %s" % road_gen_path)
+                if road_gen:
+                                road_gen.steering = steer_val
+                else:
+                                push_warning("RoadRenderer not found: %s" % road_gen_path)
+
+func _on_hitbox_body_entered(body: Node) -> void:
+                if road_gen:
+                                road_gen.current_speed *= 0.5
 
 # ------------------------------------------------------------------
 # Helper functions


### PR DESCRIPTION
## Summary
- add collision hitbox to car and short wall colliders along track sides
- cut current speed in half when car hits a wall

## Testing
- `godot --headless --path turborun -q` (failed: command not found)
- `apt-get update` (failed: repository 403)


------
https://chatgpt.com/codex/tasks/task_e_68992a5f7b688322aed0c082d6b01587